### PR TITLE
Fix adherence to `lively.project` structure

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,36 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lively.next
+        uses: actions/checkout@v3
+        with:
+          repository: LivelyKernel/lively.next
+          ref: 34f27b39a9805265b86369a67ee0ffe665dc1f8e
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.12.1'
+      - name: Install lively.next
+        run: |
+          chmod a+x ./install.sh
+          ./install.sh
+      - name: Checkout Project Repository
+        uses: actions/checkout@v3
+        with:
+          path: local_projects/engageLively--fez-intro
+      - name: Start lively.next
+        run: |
+          ./start-server.sh > /dev/null 2>&1 &
+          # wait until server is guaranteed to be running
+          sleep 30
+      - name: Run CI Test Script 
+        run:  ./scripts/test.sh engageLively--fez-intro

--- a/fonts.css
+++ b/fonts.css
@@ -1,0 +1,5 @@
+/*
+DO NOT CHANGE THE CONTENTS OF THIS FILE!
+Its contend is managed automatically by lively.next. It will automatically be loaded/bundled together with this project!
+*/
+

--- a/index.css
+++ b/index.css
@@ -1,0 +1,2 @@
+/* Use this file to add custom CSS to be used for this project! */
+/* Do NOT use @import rules in this file! */

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "lively": {
     "projectDependencies": [],
-    "boundLivelyVersion": "7423f33405ec27b047b0d21c9178fbc55106f885"
+    "boundLivelyVersion": "34f27b39a9805265b86369a67ee0ffe665dc1f8e"
   },
   "version": "0.1.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,26 @@
 {
-  "name": "fez-intro",
-  "version": "0.1.0",
+  "name": "engageLively--fez-intro",
+  "author": {
+    "name": "rickmcgeer"
+  },
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/engageLively/fez-intro"
+  },
   "scripts": {
-    "build": "./tools/build.sh"
-  }
+    "build": "rm -rf build/* && export MINIFY='' && ./tools/build.sh",
+    "build-minified": "rm -rf build/* && export MINIFY=true && ./tools/build.sh"
+  },
+  "dependencies": {
+    "@rollup/plugin-json": "4.1.0",
+    "rollup": "^2.70.2",
+    "rollup-plugin-export-default": "1.4.0",
+    "rollup-plugin-polyfill-node": "0.9.0"
+  },
+  "lively": {
+    "projectDependencies": [],
+    "boundLivelyVersion": "7423f33405ec27b047b0d21c9178fbc55106f885"
+  },
+  "version": "0.1.1"
 }


### PR DESCRIPTION
As I explained in https://github.com/LivelyKernel/lively.next/issues/949, the `package.json` was not conforming to the `lively.project` standard. On this branch, I could load the project without any problem.

Please be aware, that `lively.project` also assumes `main` to be the default branch.

I would advise the following:

1. Merge this PR.
2. Open this repository in a CLI, make sure to be on the latest `master`. 
3. `git checkout -b main`
4. `git push` (you'll probably need to create the remote branch, git will prompt you on how to do it).

Optionally, you can change the default branch in this repos settings afterwards. 